### PR TITLE
Support .NET 5.0 and .NET Standard 2.0.

### DIFF
--- a/src/Blazored.SessionStorage/Blazored.SessionStorage.csproj
+++ b/src/Blazored.SessionStorage/Blazored.SessionStorage.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
     <RazorLangVersion>3.0</RazorLangVersion>
 
     <Authors>Chris Sainty</Authors>
@@ -26,7 +26,12 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="5.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.6" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.6" />
   </ItemGroup>


### PR DESCRIPTION
Hi Chris,

Please add support for .NET 5.0. 

I'm using your library in a open source Blazor WebAssembly library for OpenID Connect https://github.com/ITfoxtec/ITfoxtec.Identity.BlazorWebAssembly.OpenidConnect.

Regards
Anders

