### PR TITLE
Add support for different ServiceLifetime

### DIFF
--- a/src/Blazored.SessionStorage/ServiceCollectionExtensions.cs
+++ b/src/Blazored.SessionStorage/ServiceCollectionExtensions.cs
@@ -1,9 +1,10 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using Blazored.SessionStorage.JsonConverters;
 using Blazored.SessionStorage.Serialization;
 using Blazored.SessionStorage.StorageOptions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Blazored.SessionStorage
 {
@@ -13,18 +14,18 @@ namespace Blazored.SessionStorage
         public static IServiceCollection AddBlazoredSessionStorage(this IServiceCollection services)
             => AddBlazoredSessionStorage(services, null);
 
-        public static IServiceCollection AddBlazoredSessionStorage(this IServiceCollection services, Action<SessionStorageOptions> configure)
+        public static IServiceCollection AddBlazoredSessionStorage(this IServiceCollection services, Action<SessionStorageOptions> configure, ServiceLifetime servicesLifetime = ServiceLifetime.Scoped)
         {
-            return services
-                .AddScoped<IJsonSerializer, SystemTextJsonSerializer>()
-                .AddScoped<IStorageProvider, BrowserStorageProvider>()
-                .AddScoped<ISessionStorageService, SessionStorageService>()
-                .AddScoped<ISyncSessionStorageService, SessionStorageService>()
-                .Configure<SessionStorageOptions>(configureOptions =>
-                {
-                    configure?.Invoke(configureOptions);
-                    configureOptions.JsonSerializerOptions.Converters.Add(new TimespanJsonConverter());
-                });
+            services.TryAdd(new ServiceDescriptor(typeof(IJsonSerializer), typeof(SystemTextJsonSerializer), servicesLifetime));
+            services.TryAdd(new ServiceDescriptor(typeof(IStorageProvider), typeof(BrowserStorageProvider), servicesLifetime));
+            services.TryAdd(new ServiceDescriptor(typeof(ISessionStorageService), typeof(SessionStorageService), servicesLifetime));
+            services.TryAdd(new ServiceDescriptor(typeof(ISyncSessionStorageService), typeof(SessionStorageService), servicesLifetime));
+            services.Configure<SessionStorageOptions>(configureOptions =>
+            {
+                configure?.Invoke(configureOptions);
+                configureOptions.JsonSerializerOptions.Converters.Add(new TimespanJsonConverter());
+            });
+            return services;
         }
     }
 }


### PR DESCRIPTION
I needed to inject the services in classes with `Singleton` lifetimes (in a Blazor WASM app), so I needed a different lifetime than `Scoped`. Since the classes have an `internal` visibility modifier, I could not register them by hand.

I took the liberty to use `TryAdd` instead of `Add` so someone could replace bindings beforehand instead of registering overrides after. Please let me know if you prefer `Add` instead.