### PR TITLE
Net8

### DIFF
--- a/samples/BlazorServer/BlazorServer.csproj
+++ b/samples/BlazorServer/BlazorServer.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/BlazorServer/BlazorServer.csproj
+++ b/samples/BlazorServer/BlazorServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/BlazorWebAssembly/BlazorWebAssembly.csproj
+++ b/samples/BlazorWebAssembly/BlazorWebAssembly.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.0" PrivateAssets="all" />
-    <PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.8" PrivateAssets="all" />
+    <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/bUnitExample/bUnitExample.csproj
+++ b/samples/bUnitExample/bUnitExample.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="bunit.web" Version="1.12.6" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="bunit.web" Version="1.31.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Blazored.SessionStorage.TestExtensions/Blazored.SessionStorage.TestExtensions.csproj
+++ b/src/Blazored.SessionStorage.TestExtensions/Blazored.SessionStorage.TestExtensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
 
     <Authors>Chris Sainty</Authors>
     <Company></Company>
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="bunit.core" Version="1.13.5" />
+    <PackageReference Include="bunit.core" Version="1.31.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Blazored.SessionStorage/Blazored.SessionStorage.csproj
+++ b/src/Blazored.SessionStorage/Blazored.SessionStorage.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
 
     <Authors>Chris Sainty</Authors>
     <Company></Company>
@@ -36,6 +36,10 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="$(DotNet7Version)" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="$(DotNet8Version)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Blazored.SessionStorage.Tests/Blazored.SessionStorage.Tests.csproj
+++ b/tests/Blazored.SessionStorage.Tests/Blazored.SessionStorage.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
@@ -11,16 +11,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="Moq" Version="4.18.3" />
-    <PackageReference Include="System.Text.Json" Version="7.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Blazored.SessionStorage.Tests/SessionStorageServiceTests/GetItemAsStringAsync.cs
+++ b/tests/Blazored.SessionStorage.Tests/SessionStorageServiceTests/GetItemAsStringAsync.cs
@@ -35,13 +35,13 @@ public class GetItemAsStringAsync
     [InlineData("")]
     [InlineData("  ")]
     [InlineData(null)]
-    public void ThrowsArgumentNullException_When_KeyIsInvalid(string key)
+    public async Task ThrowsArgumentNullException_When_KeyIsInvalid(string key)
     {
         // arrange / act
         var action = new Func<Task>(async () => await _sut.GetItemAsStringAsync(key));
 
         // assert
-        Assert.ThrowsAsync<ArgumentNullException>(action);
+        await Assert.ThrowsAsync<ArgumentNullException>(action);
     }
         
     [Theory]

--- a/tests/Blazored.SessionStorage.Tests/SessionStorageServiceTests/GetItemAsync.cs
+++ b/tests/Blazored.SessionStorage.Tests/SessionStorageServiceTests/GetItemAsync.cs
@@ -35,13 +35,13 @@ public class GetItemAsync
     [InlineData("")]
     [InlineData("  ")]
     [InlineData(null)]
-    public void ThrowsArgumentNullException_When_KeyIsInvalid(string key)
+    public async Task ThrowsArgumentNullException_When_KeyIsInvalid(string key)
     {
         // arrange / act
         var action = new Func<Task>(async () => await _sut.GetItemAsync<object>(key));
 
         // assert
-        Assert.ThrowsAsync<ArgumentNullException>(action);
+        await Assert.ThrowsAsync<ArgumentNullException>(action);
     }
         
     [Theory]

--- a/tests/Blazored.SessionStorage.Tests/SessionStorageServiceTests/RemoveItemAsync.cs
+++ b/tests/Blazored.SessionStorage.Tests/SessionStorageServiceTests/RemoveItemAsync.cs
@@ -34,13 +34,13 @@ public class RemoveItemAsync
     [InlineData("")]
     [InlineData("  ")]
     [InlineData(null)]
-    public void ThrowsArgumentNullException_When_KeyIsInvalid(string key)
+    public async Task ThrowsArgumentNullException_When_KeyIsInvalid(string key)
     {
         // arrange / act
         var action = new Func<Task>(async () => await _sut.RemoveItemAsync(key));
 
         // assert
-        Assert.ThrowsAsync<ArgumentNullException>(action);
+        await Assert.ThrowsAsync<ArgumentNullException>(action);
     }
 
     [Fact]

--- a/tests/Blazored.SessionStorage.Tests/SessionStorageServiceTests/SetItemAsStringAsync.cs
+++ b/tests/Blazored.SessionStorage.Tests/SessionStorageServiceTests/SetItemAsStringAsync.cs
@@ -34,25 +34,25 @@ public class SetItemAsStringAsync
     [InlineData("")]
     [InlineData("  ")]
     [InlineData(null)]
-    public void ThrowsArgumentNullException_When_KeyIsInvalid(string key)
+    public async Task ThrowsArgumentNullException_When_KeyIsInvalid(string key)
     {
         // arrange / act
         const string data = "Data";
         var action = new Func<Task>(async () => await _sut.SetItemAsStringAsync(key, data));
 
         // assert
-        Assert.ThrowsAsync<ArgumentNullException>(action);
+        await Assert.ThrowsAsync<ArgumentNullException>(action);
     }
         
     [Fact]
-    public void ThrowsArgumentNullException_When_DataIsNull()
+    public async Task ThrowsArgumentNullException_When_DataIsNull()
     {
         // arrange / act
         var data = (string)null;
         var action = new Func<Task>(async () => await _sut.SetItemAsStringAsync("MyValue", data));
 
         // assert
-        Assert.ThrowsAsync<ArgumentNullException>(action);
+        await Assert.ThrowsAsync<ArgumentNullException>(action);
     }
 
     [Fact]

--- a/tests/Blazored.SessionStorage.Tests/SessionStorageServiceTests/SetItemAsync.cs
+++ b/tests/Blazored.SessionStorage.Tests/SessionStorageServiceTests/SetItemAsync.cs
@@ -35,14 +35,14 @@ public class SetItemAsync
     [InlineData("")]
     [InlineData("  ")]
     [InlineData(null)]
-    public void ThrowsArgumentNullException_When_KeyIsInvalid(string key)
+    public async Task ThrowsArgumentNullException_When_KeyIsInvalid(string key)
     {
         // arrange / act
         const string data = "Data";
         var action = new Func<Task>(async () => await _sut.SetItemAsync(key, data));
 
         // assert
-        Assert.ThrowsAsync<ArgumentNullException>(action);
+        await Assert.ThrowsAsync<ArgumentNullException>(action);
     }
 
     [Fact]


### PR DESCRIPTION
- `Blazored.SessionStorage` and `Blazored.SessionStorage.TestExtensions` projects support .net 8 (in addition to 6 & 7)
- all other projects migrated to .net 8 (from 7)
- all nuget packages for all projects updated to the latest versions
- unit tests for async features now use `async/await` keywords as required by nuget package updates in the unit test project

all unit tests pass.